### PR TITLE
Standardize form button and input styling 

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -87,10 +87,6 @@ footer a:visited {
   color: #fff;
 }
 
-.header-container h2 {
-  margin-bottom: 2vh;
-}
-
 .btn-link {     /* used on <a> tags styled as buttons */
   border-radius: 10px;
   padding: .5rem 1.5rem;
@@ -155,7 +151,10 @@ h1 {
 h2 {
   font-size: 1.5rem;
   font-weight: 600;
-  /* margin-bottom: 2.5rem; */
+}
+
+.heading-container h2 {
+  margin-bottom: 2.5rem;
 }
 
 .lottie-container {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -72,7 +72,7 @@ footer {
   color: #fff;
 }
 
-/* link styling */
+/* link and button styling */
 
 nav li {
   list-style-type: none;
@@ -91,9 +91,21 @@ footer a:visited {
   margin-bottom: 2vh;
 }
 
-.btn-link {
+.btn-link {     /* used on <a> tags styled as buttons */
   border-radius: 10px;
   padding: .5rem 1.5rem;
+  text-decoration: none;
+}
+
+/* used on all form-submit buttons (login, signup, books) */
+.btn-submit {      
+  border-radius: 10px;
+  padding: .5rem 1.5rem;
+  font: inherit;  
+  cursor: pointer;
+  border: none;
+  align-self: center;
+  cursor: pointer;
   text-decoration: none;
 }
 
@@ -154,7 +166,7 @@ h2 {
 
 /* styling for Books page */
 
-.row{
+.row {
   display: flex;
   margin-top: 4vh;
 }
@@ -231,6 +243,19 @@ h2 {
   display: none;
 }
 
+/* General styling for forms */
+
+input[type="text"], input[type="email"], input[type="password"] {
+  font-family: "Edu TAS Beginner", sans-serif;
+  font-size: 1.25rem;
+  margin: 0 0 10px 0;
+  padding: 5px;
+  width: 15rem;
+  height: 2rem;
+  border: 1px solid #889397;
+  border-radius: 3px;
+}
+
 /* styling for the form to add books */
 
 #book-form {
@@ -246,22 +271,6 @@ h2 {
   -webkit-box-shadow: 0 0 10px 2px gray;
   box-shadow: 0 0 10px 2px gray;
   padding: 25px;
-}
-
-#book-form input, button {
-  font-family: "Edu TAS Beginner", sans-serif;
-  font-size: 1.25rem;
-}
-
-#books-submit-button {
-  background-color: #264653;
-  color: white;
-  font-weight: bold;
-  border-radius: 5px;
-}
-
-#books-submit-button:hover {
-  background-color: #008F95;
 }
 
 #book-form label {
@@ -287,13 +296,6 @@ h2 {
   padding: 3px;
 }
 
-#books-submit-button {
-  width: 25%;
-  margin-top: 10px;
-  padding: 3px;
-}
-
-
 /*checkedOut spans*/
 .checker:hover {
   cursor: pointer;
@@ -303,7 +305,7 @@ h2 {
 /* styling for Login and Signup pages */
 
 .login, .signup {
-  color:  blue;
+  color: #000;
   width: 600px;
   display: flex;
   flex-direction: column;
@@ -335,20 +337,5 @@ h2 {
   align-items: center;
 }
 
-#login-form input, #signup-form input {
-  margin: 3px 0;
-  padding: 3px;
-}
 
-#login-submit-button, #signup-submit-button {
-  align-self: center;
-  cursor: pointer;
-  font-family: "Edu TAS Beginner", sans-serif;
-  width: 60px;
-  height: 26px;
-  font-size: 1rem;
-  border-radius: 10px;
-  text-decoration: none;
-  border: none;
-}
 

--- a/views/books.ejs
+++ b/views/books.ejs
@@ -37,7 +37,7 @@
       <section class="row">
           <section class="column">
                 <h1>Welcome!</h1>
-                <h2 class="available"><%= user.userName %> has <%= available %> <%= available === 1 ? 'book' : 'books'%> available.</h2>
+                <h2 class="available"><%= user.firstName %> has <%= available %> <%= available === 1 ? 'book' : 'books'%> available.</h2>
                 <form id="book-form" action="/books/createBook" method='POST'>
                   <h2>Add a Book</h2>
                     <div>
@@ -60,7 +60,7 @@
                       <label for="bookNotes">Notes about Book:</label>
                       <input class="input-field" type="text" placeholder="Notes" id="bookNotes" name='bookNotes'>
                     </div>
-                      <input id="books-submit-button" type="submit">
+                      <input class="btn-submit btn-primary" type="submit">
                 </form>
           </section>
           <section class="column">

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -39,7 +39,7 @@
         <main>
             <div class="accent-spacer"></div>
             <section class="hero">
-                <div class="header-container">
+                <div class="heading-container">
                     <h1>Knowledge World</h1>
                     <h2>Your digital library</h2>
                     <a href="/signup" class="btn-link btn-primary"> Start collecting</a>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -52,7 +52,7 @@
         <form id="login-form" action="/login" method="POST">
             <input type="email" name="email" placeholder="Email">
             <input type="password" name="password" placeholder="Password">
-            <input class="btn-link btn-primary" id="login-submit-button" type="submit">
+            <input class="btn-submit btn-primary" type="submit">
         </form>
     </section>
     </main>

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -48,11 +48,11 @@
         <form id="signup-form" action="/signup" method="POST">
             <input type="text" name="userName" placeholder="User Name">
             <input type="email" name="email" placeholder="Email">
-            <input type="firstName" name="firstName" placeholder="First Name">
-            <input type="lastName" name="lastName" placeholder="Last Name">
+            <input type="text" name="firstName" placeholder="First Name">
+            <input type="text" name="lastName" placeholder="Last Name">
             <input type="password" name="password" placeholder="Password">
             <input type="password" name="confirmPassword" placeholder="Confirm Password">
-            <input id="signup-submit-button" class="btn-link btn-primary" type="submit">
+            <input class="btn-submit btn-primary" type="submit">
         </form>
     </section> 
     </main> 


### PR DESCRIPTION
- I overrode the browser default styling on the form submit buttons, to make them match the links (styled as buttons) on the homepage and header.  (style.css, lines 97-106)
- I extended missbabelfish's styling of the form input text on the books page to the other inputs on the login and signup pages. (style.css, lines 247-255)
- In making these changes, I eliminated some CSS that used ID selectors for individual buttons and form inputs, using class and attribute selectors. 
- I fixed the h2 bottom margin on the homepage. 

<img width="493" alt="Screen Shot 2022-09-04 at 8 24 06 PM" src="https://user-images.githubusercontent.com/81911167/188340093-2590a896-0a94-45b3-b4c1-be79580d44fe.png">

<img width="498" alt="Screen Shot 2022-09-04 at 8 24 14 PM" src="https://user-images.githubusercontent.com/81911167/188340096-5065fb46-9779-46e5-8d65-41d309b44442.png">

<img width="981" alt="Screen Shot 2022-09-04 at 8 24 43 PM" src="https://user-images.githubusercontent.com/81911167/188340100-2a280494-00c2-4625-9591-df61b4fcc563.png">
